### PR TITLE
Improve permission handling of the wakeword page

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -256,6 +256,16 @@ const openWakeword = util.serializeCalls(async function() {
   wakewordMaybeOpen = true;
 });
 
+registerHandler("focusWakewordTab", async (message, sender) => {
+  const tab = await browserUtil.activeTab();
+  await browserUtil.makeTabActive(sender.tab.id);
+  return tab.id;
+});
+
+registerHandler("unfocusWakewordTab", async message => {
+  await browserUtil.makeTabActive(message.tabId);
+});
+
 // These message handlers are kept in main.js to avoid cases where the module
 // (such as telemetry) doesn't or shouldn't know about this messaging, or where
 // a module (such as settings or log) can be used from the background page or the

--- a/extension/recorder/wakeword.js
+++ b/extension/recorder/wakeword.js
@@ -3,6 +3,7 @@
 import * as settings from "../settings.js";
 
 const LISTENING_TIMEOUT = 2000;
+const MIC_PERMISSION_TIMEOUT = 5000;
 let enabled = false;
 let lastInvoked = 0;
 
@@ -10,36 +11,59 @@ const micAudioProcessor = new MicAudioProcessor(audioConfig);
 const model = new SpeechResModel("RES8", commands);
 const inferenceEngine = new InferenceEngine(inferenceEngineConfig, commands);
 
-function startWatchword() {
-  micAudioProcessor
-    .getMicPermission()
-    .done(function() {
-      setInterval(function() {
-        const offlineProcessor = new OfflineAudioProcessor(
-          audioConfig,
-          micAudioProcessor.getData()
-        );
-        offlineProcessor.getMFCC().done(async function(mfccData) {
-          inferenceEngine.infer(mfccData, model, commands);
+// micAudioProcessor expects this to exist so it can report the progress, but it doesn't
+// apply to what we're doing here, so we have to stub it out:
+window.visualizer = () => {};
 
-          // eslint-disable-next-line no-unused-vars
-          const command = inferenceEngine.infer(mfccData, model, commands);
-          // FIXME: use command to do different things (right now it only wakes)
-
-          if (inferenceEngine.sequencePresent()) {
-            if (Date.now() - lastInvoked > LISTENING_TIMEOUT) {
-              await callWakeword();
-            }
-          }
-        });
-      }, predictionFrequency);
-    })
-    .fail(function() {
-      alert("mic permission is required, please enable the mic usage!");
+async function getMicPermission() {
+  let restoreTabId;
+  const timeoutId = setTimeout(async () => {
+    restoreTabId = await browser.runtime.sendMessage({
+      type: "focusWakewordTab",
     });
+  }, MIC_PERMISSION_TIMEOUT);
+  const deferred = micAudioProcessor.getMicPermission();
+  return new Promise((resolve, reject) => {
+    deferred.always(() => {
+      clearTimeout(timeoutId);
+      if (restoreTabId) {
+        browser.runtime.sendMessage({
+          type: "unfocusWakewordTab",
+          tabId: restoreTabId,
+        });
+      }
+    });
+    deferred.done(resolve).fail(reject);
+  });
+}
 
-  log.info("Listening for watchword: Hey Firefox");
+async function startWatchword() {
   enabled = true;
+  try {
+    await getMicPermission();
+  } catch (e) {
+    window.alert("mic permission is required, please enable the mic usage!");
+  }
+  setInterval(function() {
+    const offlineProcessor = new OfflineAudioProcessor(
+      audioConfig,
+      micAudioProcessor.getData()
+    );
+    offlineProcessor.getMFCC().done(async function(mfccData) {
+      inferenceEngine.infer(mfccData, model, commands);
+
+      // eslint-disable-next-line no-unused-vars
+      const command = inferenceEngine.infer(mfccData, model, commands);
+      // FIXME: use command to do different things (right now it only wakes)
+
+      if (inferenceEngine.sequencePresent()) {
+        if (Date.now() - lastInvoked > LISTENING_TIMEOUT) {
+          await callWakeword();
+        }
+      }
+    });
+  }, predictionFrequency);
+  log.info("Listening for watchword: Hey Firefox");
 }
 
 async function callWakeword() {


### PR DESCRIPTION
Fixes a problem where the wakeword code expects there to be a visualizer function (stubbed out for us).

Focus over to the wakeword window when necessary on startup
