### PR TITLE
Improve permission-on-startup for wakeword page

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -251,14 +251,24 @@ const openWakeword = util.serializeCalls(async function() {
     await sendMessage({ type: "updateWakeword" }, { tabId: tab.id });
     await browserUtil.makeTabActive(activeTab.id);
   } else {
-    await sendMessage({ type: "updateWakeword" }, { tabId: tabs[0].id });
+    try {
+      await sendMessage({ type: "updateWakeword" }, { tabId: tabs[0].id });
+    } catch (e) {
+      if (e.message.includes("Could not establish connection")) {
+        await browser.tabs.reload(tabs[0].id);
+      }
+      throw e;
+    }
   }
   wakewordMaybeOpen = true;
 });
 
 registerHandler("focusWakewordTab", async (message, sender) => {
   const tab = await browserUtil.activeTab();
-  await browserUtil.makeTabActive(sender.tab.id);
+  // For some reason this takes a long time to return, too long, and
+  // doesn't return in time, so we let it run in the background and return
+  // the tab.id fast:
+  browserUtil.makeTabActive(sender.tab.id);
   return tab.id;
 });
 
@@ -337,7 +347,11 @@ settings.watch("enableWakeword", openWakeword);
 settings.watch("wakewords", openWakeword);
 settings.watch("wakewordSensitivity", openWakeword);
 
-openWakeword();
+// If the wakeword is opened too soon, there can be a permission-related race condition
+// where the wakeword page won't load:
+setTimeout(() => {
+  openWakeword();
+}, 500);
 
 function setUninstallURL() {
   const url = telemetry.createSurveyUrl(UNINSTALL_SURVEY);

--- a/extension/communicate.js
+++ b/extension/communicate.js
@@ -116,6 +116,9 @@ export async function sendMessage(message, options) {
         if (e.message.includes("Missing host permission for the tab")) {
           e.displayMessage = "That does not work on this kind of page";
         }
+        if (e.message) {
+          e.message += " In message type=" + message.type;
+        }
         throw e;
       }
     );

--- a/extension/recorder/wakeword.js
+++ b/extension/recorder/wakeword.js
@@ -1,9 +1,10 @@
 /* globals log, MicAudioProcessor, audioConfig, commands, SpeechResModel, inferenceEngineConfig, InferenceEngine, OfflineAudioProcessor, predictionFrequency */
 
 import * as settings from "../settings.js";
+import { serializeCalls } from "../util.js";
 
 const LISTENING_TIMEOUT = 2000;
-const MIC_PERMISSION_TIMEOUT = 5000;
+const MIC_PERMISSION_TIMEOUT = 2000;
 let enabled = false;
 let lastInvoked = 0;
 
@@ -80,17 +81,18 @@ function stopWatchword() {
   enabled = false;
 }
 
-export async function updateWakeword() {
+export const updateWakeword = serializeCalls(async function() {
   const userSettings = await settings.getSettings();
   if (userSettings.enableWakeword) {
     // FIXME: if we use other settings besides enableWakeword (e.g., userSettings.wakewords,
     // userSettings.wakewordSensitivity), we should restart the listener if those settings change
     if (!enabled) {
-      startWatchword();
+      return startWatchword();
     }
   } else if (enabled) {
-    stopWatchword();
+    return stopWatchword();
   }
-}
+  return null;
+});
 
 updateWakeword();


### PR DESCRIPTION
This fixes some of the focus swapping for getting mic permission on startup. Also adds some messaging debugging information.

Delays opening the wakeword page by a smidge to avoid some permission race conditions
