### PR TITLE
Fix #1269, only show Lionel with 'hello'

### DIFF
--- a/extension/intents/self/self.js
+++ b/extension/intents/self/self.js
@@ -31,6 +31,13 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "self.openLexicon",
   async run(context) {
+    await browserUtil.openOrActivateTab("/views/lexicon.html");
+  },
+});
+
+intentRunner.registerIntent({
+  name: "self.hello",
+  async run(context) {
     const imageCard = "/assets/images/lionel-richie.jpg";
     const card = {
       answer: {

--- a/extension/intents/self/self.toml
+++ b/extension/intents/self/self.toml
@@ -23,7 +23,7 @@ match = """
   tell me about (this | firefox voice | this extension | voice)
   help
   what (else |) (can | should) (I | you) (do | say | ask) (you | from you | of you |)
-  (hello | hi)
+  hi
   what commands (can | could | will | would |) (I | you |) (say | follow | use | speak |)
   (hello | hi |) how are you (doing |)
   show options
@@ -65,6 +65,11 @@ test = true
 [[self.openLexicon.example]]
 phrase = "Show options"
 
+[self.hello]
+description = "Shows Lionel Richie's handsom face"
+match = """
+  hello
+"""
 
 [self.openOptions]
 description = "Opens the options page"


### PR DESCRIPTION
This lets other help-related phrases show the lexicon
