### PR TITLE
Use tensorflow library that doesn't require shims

### DIFF
--- a/extension/manifest.json.ejs
+++ b/extension/manifest.json.ejs
@@ -78,7 +78,7 @@
       <% } %>
     "default_popup": "popup/popup.html"
   },
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';",
+  "content_security_policy": "script-src 'self'; object-src 'self';",
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {

--- a/extension/wakeword/wakeword.html
+++ b/extension/wakeword/wakeword.html
@@ -27,7 +27,7 @@
     <script src="../js/vendor/sentry.js"></script>
     <script src="../catcher.js"></script>
     <script src="../js/vendor/jquery.min.js"></script>
-    <script src="../js/vendor/tf.min.js"></script>
+    <script src="../js/vendor/tf.es2017.js"></script>
     <script src="../js/vendor-honkling/meyda.js"></script>
     <script src="../js/vendor-honkling/config.js"></script>
     <script src="../js/vendor-honkling/util.js"></script>

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jest": "npm run build:intent-metadata && jest",
     "build": "npm-run-all build:* package-prod",
     "build:templates": "mkdir -p extension/views && node bin/fill-templates.js",
-    "build:deps": "mkdir -p extension/js/vendor/ extension/css/vendor/ ; for file in @tensorflow/tfjs/dist/tf.min.js lottie-web/build/player/lottie.min.js fuse.js/dist/fuse.js react/umd/react.production.min.js react-dom/umd/react-dom.production.min.js chrono-node/dist/chrono.min.js jquery/dist/jquery.min.js; do cp node_modules/$file extension/js/vendor/ ; done ; cp \"node_modules/@sentry/browser/build/bundle.es6.min.js\" extension/js/vendor/sentry.js",
+    "build:deps": "mkdir -p extension/js/vendor/ extension/css/vendor/ ; for file in @tensorflow/tfjs/dist/tf.es2017.js lottie-web/build/player/lottie.min.js fuse.js/dist/fuse.js react/umd/react.production.min.js react-dom/umd/react-dom.production.min.js chrono-node/dist/chrono.min.js jquery/dist/jquery.min.js; do cp node_modules/$file extension/js/vendor/ ; done ; cp \"node_modules/@sentry/browser/build/bundle.es6.min.js\" extension/js/vendor/sentry.js",
     "build:manifest": "node bin/substitute-manifest.js",
     "build:intent-metadata": "node bin/parse-intent-toml.js",
     "build:jsx": "babel --relative --out-dir ../build --only '**/*.jsx' extension/ && node bin/move-changed-build-files.js",


### PR DESCRIPTION
The standard tf.min.js library uses Function() (which is unsafe) to handle some missing JavaScript functionality. We don't need that, AND it breaks our content-security policy.
